### PR TITLE
Fix: Refresh Token 관련 로직 수정

### DIFF
--- a/src/main/java/com/couponmoa/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/couponmoa/backend/common/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     EXPIRED_JWT(UNAUTHORIZED, "만료된 JWT 토큰입니다."),
     UNSUPPORTED_JWT(BAD_REQUEST, "지원되지 않는 JWT 토큰입니다."),
     UNAUTHORIZED_ACCESS(UNAUTHORIZED,"로그인 되어 있지 않습니다." ),
+    REFRESH_TOKEN_FORBIDDEN(FORBIDDEN,"Refresh Token으로 접근할 수 없습니다."),
 
     // user
     INVALID_USER_ROLE(FORBIDDEN,"유효하지 않은 권한입니다."),

--- a/src/main/java/com/couponmoa/backend/common/service/RedisService.java
+++ b/src/main/java/com/couponmoa/backend/common/service/RedisService.java
@@ -19,4 +19,8 @@ public class RedisService {
     public String get(String key) {
         return (String) redisTemplate.opsForValue().get(key);
     }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
 }

--- a/src/main/java/com/couponmoa/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/couponmoa/backend/config/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.couponmoa.backend.config;
 
 import com.couponmoa.backend.common.exception.ApplicationException;
 import com.couponmoa.backend.common.exception.ErrorCode;
+import com.couponmoa.backend.common.service.RedisService;
 import com.couponmoa.backend.domain.user.dto.AuthUser;
 import com.couponmoa.backend.domain.user.enums.UserRole;
 import io.jsonwebtoken.Claims;
@@ -25,6 +26,7 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+    private final RedisService redisService;
 
     @Override
     protected void doFilterInternal(
@@ -38,10 +40,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String jwt = jwtUtil.substringToken(authorizationHeader);
             try {
                 Claims claims = jwtUtil.extractClaims(jwt);
-
                 String tokenType = claims.get("tokenType", String.class);
+                String redisAccessToken = redisService.get("access:" + claims.getSubject());
+
                 if ("refresh".equals(tokenType)) {
                     throw new ApplicationException(ErrorCode.REFRESH_TOKEN_FORBIDDEN);
+                }
+
+                if(redisAccessToken == null || !jwt.equals(jwtUtil.substringToken(redisAccessToken))) {
+                    throw new ApplicationException(ErrorCode.INVALID_JWT);
                 }
 
                 if (SecurityContextHolder.getContext().getAuthentication() == null) {

--- a/src/main/java/com/couponmoa/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/couponmoa/backend/config/JwtAuthenticationFilter.java
@@ -39,6 +39,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             try {
                 Claims claims = jwtUtil.extractClaims(jwt);
 
+                String tokenType = claims.get("tokenType", String.class);
+                if ("refresh".equals(tokenType)) {
+                    throw new ApplicationException(ErrorCode.REFRESH_TOKEN_FORBIDDEN);
+                }
+
                 if (SecurityContextHolder.getContext().getAuthentication() == null) {
                     setAuthentication(claims);
                 }
@@ -48,6 +53,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 throw new ApplicationException(ErrorCode.EXPIRED_JWT);
             } catch (UnsupportedJwtException e) {
                 throw new ApplicationException(ErrorCode.UNSUPPORTED_JWT);
+            } catch (ApplicationException e) {
+                throw e;
             } catch (Exception e) {
                 throw new ApplicationException(ErrorCode.EXCEPTION);
             }

--- a/src/main/java/com/couponmoa/backend/config/JwtUtil.java
+++ b/src/main/java/com/couponmoa/backend/config/JwtUtil.java
@@ -40,15 +40,16 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String createToken(Long userId, String email, UserRole userRole, Long validTime) {
+    public String createToken(Long userId, String email, UserRole userRole, Long validTime, String tokenType) {
         Date date = new Date();
-        log.info("JWT 생성 - userId: {}, email: {}, 역할: {}", userId, email, userRole.name()); //
+        log.info("JWT 생성 - userId: {}, email: {}, 역할: {}, 토큰 타입: {}", userId, email, userRole.name(), tokenType); //
 
         return BEARER_PREFIX +
                 Jwts.builder()
                         .subject(String.valueOf(userId))
                         .claim("email", email)
                         .claim("userRole", userRole.getUserRole())
+                        .claim("tokenType", tokenType)
                         .expiration(new Date(date.getTime() + validTime))
                         .issuedAt(date)
                         .signWith(key)
@@ -56,11 +57,11 @@ public class JwtUtil {
     }
 
     public String createAccessToken(Long userId, String email, UserRole userRole) {
-        return this.createToken(userId, email, userRole, ACCESS_TOKEN_TIME);
+        return this.createToken(userId, email, userRole, ACCESS_TOKEN_TIME, "access");
     }
 
     public String createRefreshToken(Long userId, String email, UserRole userRole) {
-        String refreshToken =  this.createToken(userId, email, userRole, REFRESH_TOKEN_TIME);
+        String refreshToken = this.createToken(userId, email, userRole, REFRESH_TOKEN_TIME, "refresh");
         redisService.save(userId.toString(), refreshToken, Duration.ofMillis(REFRESH_TOKEN_TIME));
         return refreshToken;
     }
@@ -79,7 +80,7 @@ public class JwtUtil {
                 .parseSignedClaims(token)
                 .getPayload();
 
-        log.info("JWT 검증 완료 - userRole: {}", claims.get("userRole"));
+        log.info("JWT 검증 완료 - userRole: {}, tokenType: {}", claims.get("userRole"), claims.get("tokenType"));
         return claims;
     }
 

--- a/src/main/java/com/couponmoa/backend/config/JwtUtil.java
+++ b/src/main/java/com/couponmoa/backend/config/JwtUtil.java
@@ -57,12 +57,18 @@ public class JwtUtil {
     }
 
     public String createAccessToken(Long userId, String email, UserRole userRole) {
-        return this.createToken(userId, email, userRole, ACCESS_TOKEN_TIME, "access");
+        String accessToken = this.createToken(userId, email, userRole, ACCESS_TOKEN_TIME, "access");
+        String accessTokenKey = "access:"+userId;
+        redisService.delete(accessTokenKey);
+        redisService.save(accessTokenKey,accessToken,Duration.ofMillis(ACCESS_TOKEN_TIME));
+        return accessToken;
     }
+
 
     public String createRefreshToken(Long userId, String email, UserRole userRole) {
         String refreshToken = this.createToken(userId, email, userRole, REFRESH_TOKEN_TIME, "refresh");
-        redisService.save(userId.toString(), refreshToken, Duration.ofMillis(REFRESH_TOKEN_TIME));
+        String refreshTokenKey = "refresh:"+userId;
+        redisService.save(refreshTokenKey, refreshToken, Duration.ofMillis(REFRESH_TOKEN_TIME));
         return refreshToken;
     }
 
@@ -86,7 +92,7 @@ public class JwtUtil {
 
     public void validateToken(String refreshToken, String userId) {
         try {
-            String redisToken = redisService.get(userId);
+            String redisToken = redisService.get("refresh:"+userId);
             if (!refreshToken.equals(substringToken(redisToken))) {
                 throw new ApplicationException(ErrorCode.INVALID_JWT);
             }

--- a/src/main/java/com/couponmoa/backend/domain/user/service/AuthService.java
+++ b/src/main/java/com/couponmoa/backend/domain/user/service/AuthService.java
@@ -2,6 +2,7 @@ package com.couponmoa.backend.domain.user.service;
 
 import com.couponmoa.backend.common.exception.ApplicationException;
 import com.couponmoa.backend.common.exception.ErrorCode;
+import com.couponmoa.backend.common.service.RedisService;
 import com.couponmoa.backend.config.JwtUtil;
 import com.couponmoa.backend.domain.user.dto.request.SigninRequest;
 import com.couponmoa.backend.domain.user.dto.request.SignupRequest;
@@ -21,6 +22,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final RedisService redisService;
 
     @Transactional
     public void signup(SignupRequest signupRequest) {
@@ -66,6 +68,7 @@ public class AuthService {
         jwtUtil.validateToken(refreshToken, userId);
 
         User user = userRepository.findByIdOrElseThrow(Long.valueOf(userId), ErrorCode.USER_NOT_FOUND);
+
         String newAccessToken = jwtUtil.createAccessToken(user.getId(), user.getEmail(), user.getUserRole());
 
         return new TokenResponse(newAccessToken, refreshToken);


### PR DESCRIPTION
📌 반영 브랜치
refactor/user -> dev

🚨 연관 이슈
https://github.com/sparta-final-organization/couponmoa/issues/36

✅ 작업 내용
- 각 토큰 생성시 토큰 타입 명시
- JwtFilter에서 토큰 타입 확인 후 refresh token인 경우 예외 처리
- 토큰 재발급시 이전 토큰은 사용 못하도록 처리
- accessToken과 refreshToken 모두 redis에 저장
-  토큰 재발급시 기존 accessToken 삭제 및 저장
-  redis의 accessToken과 등록한 jwt 토큰이 일치하는지 검사하는 로직 추가