### PR TITLE
fix:(#43):ci-cd.yml에 도커 컴포즈 설치 로직 추가

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Set up Docker Buildx (optional but safe)
         uses: docker/setup-buildx-action@v3
 
+      - name: Install docker-compose
+        run: |
+          DOCKER_COMPOSE_VERSION=2.20.2
+          sudo curl -L "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+
       - name: Docker Compose Up
         run: |
           docker-compose up -d --build


### PR DESCRIPTION
# 개요
- ci-cd.yml에 도커 컴포즈 설치 로직을 추가 하였습니다

# 이하 1개 파일 수정
- .github/workflows/ci-cd.yml

## 수정 부분
- 도커 컴포즈 설치 로직 추가