### PR TITLE
feat(#33): add SOLD_OUT status & refactor user-coupon issuance

### DIFF
--- a/src/main/java/com/couponmoa/backend/domain/coupon/enums/CouponStatus.java
+++ b/src/main/java/com/couponmoa/backend/domain/coupon/enums/CouponStatus.java
@@ -8,11 +8,11 @@ import java.time.LocalDateTime;
 @Getter
 @RequiredArgsConstructor
 public enum CouponStatus {
-    UPCOMING, IN_PROGRESS, SOLE_OUT, ENDED;
+    UPCOMING, IN_PROGRESS, SOLD_OUT, ENDED;
 
     public static CouponStatus editStatus(LocalDateTime startDate, LocalDateTime endDate, int availableQuantity) {
         if (availableQuantity == 0) {
-            return CouponStatus.SOLE_OUT;
+            return CouponStatus.SOLD_OUT;
         }
 
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/couponmoa/backend/domain/coupon/enums/CouponStatus.java
+++ b/src/main/java/com/couponmoa/backend/domain/coupon/enums/CouponStatus.java
@@ -8,11 +8,11 @@ import java.time.LocalDateTime;
 @Getter
 @RequiredArgsConstructor
 public enum CouponStatus {
-    UPCOMING, IN_PROGRESS, ENDED;
+    UPCOMING, IN_PROGRESS, SOLE_OUT, ENDED;
 
     public static CouponStatus editStatus(LocalDateTime startDate, LocalDateTime endDate, int availableQuantity) {
         if (availableQuantity == 0) {
-            return CouponStatus.ENDED;
+            return CouponStatus.SOLE_OUT;
         }
 
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/couponmoa/backend/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/couponmoa/backend/domain/coupon/service/CouponService.java
@@ -122,7 +122,7 @@ public class CouponService {
             coupon.updateStatus(newStatus);
             // 상태가 IN_PROGRESS로 변경된 경우에만 알림 전송
             if (newStatus == CouponStatus.IN_PROGRESS) {
-                구독알람발송클래스.알람발송메서드(coupon);
+//                구독알람발송클래스.알람발송메서드(coupon);
             }
         }
 

--- a/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponService.java
+++ b/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponService.java
@@ -43,11 +43,6 @@ public class UserCouponService {
 
         coupon.availableQuantityDown();
 
-        // 발급 가능 수량이 다 소진되면 쿠폰의 상태를 ENDED로 전환.
-        if (coupon.getAvailableQuantity() == 0) {
-            coupon.updateStatus(CouponStatus.ENDED);
-        }
-
         couponRepository.flush();
 
         User user = userRepository.getReferenceById(userId);
@@ -83,20 +78,13 @@ public class UserCouponService {
     }
 
     private void validateCouponIssuable(Coupon coupon) {
-        validateCouponActivePeriod(coupon.getStartDate(), coupon.getEndDate());
-        validateCouponAvailableQuantity(coupon.getAvailableQuantity());
-    }
-
-    private void validateCouponActivePeriod(LocalDateTime startDate, LocalDateTime endDate) {
-        LocalDateTime now = LocalDateTime.now();
-        if (startDate.isAfter(now) || endDate.isBefore(now)) {
+        CouponStatus currentStatus = CouponStatus.editStatus(
+                coupon.getStartDate(),
+                coupon.getEndDate(),
+                coupon.getAvailableQuantity()
+        );
+        if (currentStatus != CouponStatus.IN_PROGRESS) {
             throw new ApplicationException(ErrorCode.COUPON_NOT_ACTIVE);
-        }
-    }
-
-    private void validateCouponAvailableQuantity(Integer availableQuantity) {
-        if (availableQuantity <= 0) {
-            throw new ApplicationException(ErrorCode.COUPON_SOLE_OUT);
         }
     }
 


### PR DESCRIPTION
📌 반영 브랜치
feat/coupon -> dev

🚨 연관 이슈
Resolve: https://github.com/sparta-final-organization/couponmoa/issues/33

✅ 작업 내용 리팩토링
-CouponStatus에 SOLD_OUT 상태 추가
-쿠폰 상태 계산 메서드 editStatus( )를 활용해 쿠폰 발급 가능 여부 검증 통일
-createUserCoupon() 서비스 로직 리팩토링:
  *불필요한 개별 수량 / 날짜 검증 메서드 제거
  *editStatus(...) 기준으로 IN_PROGRESS 상태만 발급 허용
  *availableQuantityDown() 내부에서 수량 0일 경우 자동 ENDED 상태 전환

🎯 단독 테스트 결과
swagger 테스트 성공