### PR TITLE
쿠폰 만료 스케줄러 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
 
     //SMTP(send mail)
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // jobrunr
+    implementation 'org.jobrunr:jobrunr-spring-boot-3-starter:7.4.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/couponmoa/backend/common/scheduler/CouponStatusUpdateService.java
+++ b/src/main/java/com/couponmoa/backend/common/scheduler/CouponStatusUpdateService.java
@@ -1,0 +1,22 @@
+package com.couponmoa.backend.common.scheduler;
+
+import com.couponmoa.backend.domain.usercoupon.repository.UserCouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.jobrunr.jobs.annotations.Job;
+import org.jobrunr.jobs.annotations.Recurring;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CouponStatusUpdateService {
+
+    private final UserCouponRepository userCouponRepository;
+
+    @Recurring(id = "coupon-expire-job", cron = "0 0 * * *")
+    @Job(name = "Update the status of expired user coupons to ‘expired’", retries = 3)
+    @Transactional
+    public void updateCouponStatusExpired() {
+        userCouponRepository.updateCouponStatusExpired();
+    }
+}

--- a/src/main/java/com/couponmoa/backend/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/couponmoa/backend/domain/coupon/entity/Coupon.java
@@ -110,5 +110,9 @@ public class Coupon extends BaseEntity {
         }
         availableQuantity--;
         issuedQuantity++;
+
+        if (availableQuantity == 0) {
+            this.status = CouponStatus.SOLD_OUT;
+        }
     }
 }

--- a/src/main/java/com/couponmoa/backend/domain/usercoupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/couponmoa/backend/domain/usercoupon/repository/UserCouponRepository.java
@@ -6,6 +6,7 @@ import com.couponmoa.backend.domain.usercoupon.entity.UserCoupon;
 import com.couponmoa.backend.domain.usercoupon.enums.UserCouponStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
@@ -25,4 +26,12 @@ public interface UserCouponRepository extends BaseRepository<UserCoupon, Long> {
 
     @Query("SELECT uc FROM UserCoupon uc JOIN FETCH uc.coupon c JOIN FETCH c.store s WHERE uc.code = :code")
     Optional<UserCoupon> findByCodeWithCouponAndStore(String code);
+
+    @Modifying
+    @Query("""
+                 UPDATE UserCoupon uc SET uc.status = 'EXPIRED', uc.modifiedAt = CURRENT_TIMESTAMP
+                 WHERE uc.status = 'UNUSED'
+                 AND uc.coupon.id IN (SELECT c.id FROM Coupon c WHERE c.expiryDate <= CURRENT_TIMESTAMP)
+            """)
+    void updateCouponStatusExpired();
 }

--- a/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponService.java
+++ b/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponService.java
@@ -9,9 +9,9 @@ import com.couponmoa.backend.domain.store.entity.Store;
 import com.couponmoa.backend.domain.user.entity.User;
 import com.couponmoa.backend.domain.user.repository.UserRepository;
 import com.couponmoa.backend.domain.usercoupon.dto.request.UserCouponRequest;
+import com.couponmoa.backend.domain.usercoupon.dto.response.UseUserCouponResponse;
 import com.couponmoa.backend.domain.usercoupon.dto.response.UserCouponCodeResponse;
 import com.couponmoa.backend.domain.usercoupon.dto.response.UserCouponResponse;
-import com.couponmoa.backend.domain.usercoupon.dto.response.UseUserCouponResponse;
 import com.couponmoa.backend.domain.usercoupon.entity.UserCoupon;
 import com.couponmoa.backend.domain.usercoupon.enums.UserCouponStatus;
 import com.couponmoa.backend.domain.usercoupon.repository.UserCouponRepository;
@@ -22,8 +22,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 @Service
 @Transactional(readOnly = true)
@@ -42,12 +40,6 @@ public class UserCouponService {
         validateCouponNotAlreadyIssued(userId, couponId);
 
         coupon.availableQuantityDown();
-
-        // 발급 가능 수량이 다 소진되면 쿠폰의 상태를 ENDED로 전환.
-        if (coupon.getAvailableQuantity() == 0) {
-            coupon.updateStatus(CouponStatus.ENDED);
-        }
-
         couponRepository.flush();
 
         User user = userRepository.getReferenceById(userId);
@@ -83,13 +75,12 @@ public class UserCouponService {
     }
 
     private void validateCouponIssuable(Coupon coupon) {
-        validateCouponActivePeriod(coupon.getStartDate(), coupon.getEndDate());
+        validateCouponActivePeriod(coupon.getStatus());
         validateCouponAvailableQuantity(coupon.getAvailableQuantity());
     }
 
-    private void validateCouponActivePeriod(LocalDateTime startDate, LocalDateTime endDate) {
-        LocalDateTime now = LocalDateTime.now();
-        if (startDate.isAfter(now) || endDate.isBefore(now)) {
+    private void validateCouponActivePeriod(CouponStatus status) {
+        if (!status.equals(CouponStatus.IN_PROGRESS)) {
             throw new ApplicationException(ErrorCode.COUPON_NOT_ACTIVE);
         }
     }

--- a/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponService.java
+++ b/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponService.java
@@ -36,7 +36,7 @@ public class UserCouponService {
     public void createUserCoupon(Long userId, Long couponId) {
         Coupon coupon = couponRepository.findActiveByIdOrElseThrow(couponId, ErrorCode.COUPON_NOT_FOUND);
 
-        validateCouponIssuable(coupon);
+        validateCouponIssuable(coupon.getStatus());
         validateCouponNotAlreadyIssued(userId, couponId);
 
         coupon.availableQuantityDown();
@@ -74,20 +74,13 @@ public class UserCouponService {
         return UseUserCouponResponse.from(userCoupon);
     }
 
-    private void validateCouponIssuable(Coupon coupon) {
-        validateCouponActivePeriod(coupon.getStatus());
-        validateCouponAvailableQuantity(coupon.getAvailableQuantity());
-    }
-
-    private void validateCouponActivePeriod(CouponStatus status) {
-        if (!status.equals(CouponStatus.IN_PROGRESS)) {
-            throw new ApplicationException(ErrorCode.COUPON_NOT_ACTIVE);
-        }
-    }
-
-    private void validateCouponAvailableQuantity(Integer availableQuantity) {
-        if (availableQuantity <= 0) {
+    private void validateCouponIssuable(CouponStatus status) {
+        if (status == CouponStatus.SOLD_OUT) {
             throw new ApplicationException(ErrorCode.COUPON_SOLE_OUT);
+        }
+
+        if (status != CouponStatus.IN_PROGRESS) {
+            throw new ApplicationException(ErrorCode.COUPON_NOT_ACTIVE);
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,8 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
+
+# JobRunr
+org.jobrunr.dashboard.enabled=true
+org.jobrunr.background-job-server.enabled=true
+org.jobrunr.jobs.metrics.enabled=true

--- a/src/test/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponServiceTest.java
+++ b/src/test/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponServiceTest.java
@@ -105,8 +105,7 @@ class UserCouponServiceTest {
         void 쿠폰_발급_수량_없음_실패() {
             ErrorCode errorCode = ErrorCode.COUPON_SOLE_OUT;
             Coupon coupon = mock();
-            given(coupon.getStatus()).willReturn(CouponStatus.IN_PROGRESS);
-            given(coupon.getAvailableQuantity()).willReturn(0);
+            given(coupon.getStatus()).willReturn(CouponStatus.SOLD_OUT);
             given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);
 
             ApplicationException thrown = assertThrows(ApplicationException.class,
@@ -123,7 +122,6 @@ class UserCouponServiceTest {
             ErrorCode errorCode = ErrorCode.USER_COUPON_ALREADY_ISSUED;
             Coupon coupon = mock();
             given(coupon.getStatus()).willReturn(CouponStatus.IN_PROGRESS);
-            given(coupon.getAvailableQuantity()).willReturn(100);
             given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);
             given(userCouponRepository.existsByUserIdAndCouponId(anyLong(), anyLong())).willReturn(true);
 
@@ -141,7 +139,6 @@ class UserCouponServiceTest {
             User user = mock();
             Coupon coupon = mock();
             given(coupon.getStatus()).willReturn(CouponStatus.IN_PROGRESS);
-            given(coupon.getAvailableQuantity()).willReturn(100);
             given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);
             given(userCouponRepository.existsByUserIdAndCouponId(anyLong(), anyLong())).willReturn(false);
             given(userRepository.getReferenceById(anyLong())).willReturn(user);

--- a/src/test/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponServiceTest.java
+++ b/src/test/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponServiceTest.java
@@ -3,6 +3,7 @@ package com.couponmoa.backend.domain.usercoupon.service;
 import com.couponmoa.backend.common.exception.ApplicationException;
 import com.couponmoa.backend.common.exception.ErrorCode;
 import com.couponmoa.backend.domain.coupon.entity.Coupon;
+import com.couponmoa.backend.domain.coupon.enums.CouponStatus;
 import com.couponmoa.backend.domain.coupon.repository.CouponRepository;
 import com.couponmoa.backend.domain.store.entity.Store;
 import com.couponmoa.backend.domain.user.entity.User;
@@ -11,10 +12,10 @@ import com.couponmoa.backend.domain.usercoupon.dto.request.UserCouponRequest;
 import com.couponmoa.backend.domain.usercoupon.dto.response.UseUserCouponResponse;
 import com.couponmoa.backend.domain.usercoupon.dto.response.UserCouponCodeResponse;
 import com.couponmoa.backend.domain.usercoupon.dto.response.UserCouponResponse;
-import com.couponmoa.backend.domain.usercoupon.repository.projection.UserCouponProjection;
 import com.couponmoa.backend.domain.usercoupon.entity.UserCoupon;
 import com.couponmoa.backend.domain.usercoupon.enums.UserCouponStatus;
 import com.couponmoa.backend.domain.usercoupon.repository.UserCouponRepository;
+import com.couponmoa.backend.domain.usercoupon.repository.projection.UserCouponProjection;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -22,7 +23,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -73,8 +73,7 @@ class UserCouponServiceTest {
         void 쿠폰_발급_기간_전_요청_실패() {
             ErrorCode errorCode = ErrorCode.COUPON_NOT_ACTIVE;
             Coupon coupon = mock();
-            given(coupon.getStartDate()).willReturn(LocalDateTime.now().plusDays(1));
-            given(coupon.getEndDate()).willReturn(LocalDateTime.now().plusDays(2));
+            given(coupon.getStatus()).willReturn(CouponStatus.UPCOMING);
             given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);
 
             ApplicationException thrown = assertThrows(ApplicationException.class,
@@ -90,8 +89,7 @@ class UserCouponServiceTest {
         void 쿠폰_발급_기간_후_요청_실패() {
             ErrorCode errorCode = ErrorCode.COUPON_NOT_ACTIVE;
             Coupon coupon = mock();
-            given(coupon.getStartDate()).willReturn(LocalDateTime.now().minusDays(2));
-            given(coupon.getEndDate()).willReturn(LocalDateTime.now().minusDays(1));
+            given(coupon.getStatus()).willReturn(CouponStatus.ENDED);
             given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);
 
             ApplicationException thrown = assertThrows(ApplicationException.class,
@@ -107,8 +105,7 @@ class UserCouponServiceTest {
         void 쿠폰_발급_수량_없음_실패() {
             ErrorCode errorCode = ErrorCode.COUPON_SOLE_OUT;
             Coupon coupon = mock();
-            given(coupon.getStartDate()).willReturn(LocalDateTime.now().minusDays(1));
-            given(coupon.getEndDate()).willReturn(LocalDateTime.now().plusDays(1));
+            given(coupon.getStatus()).willReturn(CouponStatus.IN_PROGRESS);
             given(coupon.getAvailableQuantity()).willReturn(0);
             given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);
 
@@ -125,8 +122,7 @@ class UserCouponServiceTest {
         void 쿠폰_발급_중복_요청_실패() {
             ErrorCode errorCode = ErrorCode.USER_COUPON_ALREADY_ISSUED;
             Coupon coupon = mock();
-            given(coupon.getStartDate()).willReturn(LocalDateTime.now().minusDays(1));
-            given(coupon.getEndDate()).willReturn(LocalDateTime.now().plusDays(1));
+            given(coupon.getStatus()).willReturn(CouponStatus.IN_PROGRESS);
             given(coupon.getAvailableQuantity()).willReturn(100);
             given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);
             given(userCouponRepository.existsByUserIdAndCouponId(anyLong(), anyLong())).willReturn(true);
@@ -144,8 +140,7 @@ class UserCouponServiceTest {
         void 쿠폰_발급_성공() {
             User user = mock();
             Coupon coupon = mock();
-            given(coupon.getStartDate()).willReturn(LocalDateTime.now().minusDays(1));
-            given(coupon.getEndDate()).willReturn(LocalDateTime.now().plusDays(1));
+            given(coupon.getStatus()).willReturn(CouponStatus.IN_PROGRESS);
             given(coupon.getAvailableQuantity()).willReturn(100);
             given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);
             given(userCouponRepository.existsByUserIdAndCouponId(anyLong(), anyLong())).willReturn(false);


### PR DESCRIPTION
## 📌 반영 브랜치
feat/coupon-expiry-scheduler -> dev

## 🚨 연관 이슈
Resolve: #52 

## ✅ 작업 내용 `기능 추가`
- JobRunr 의존성 추가
- 매 자정마다 만료 기간이 지난 쿠폰의 상태를 만료로 변경하는 스케줄러 구현
- 분산 환경에서 중복 호출 방지, 실패 시 재시도, 모니터링 기능 포함
- localhost:8000/dashboard 에서 등록한 작업 확인 가능