### PR TITLE
쿠폰 발급 시 동시성 제어 구현

### DIFF
--- a/src/main/java/com/couponmoa/backend/CouponmoaApplication.java
+++ b/src/main/java/com/couponmoa/backend/CouponmoaApplication.java
@@ -3,7 +3,9 @@ package com.couponmoa.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 @EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 public class CouponmoaApplication {

--- a/src/main/java/com/couponmoa/backend/CouponmoaApplication.java
+++ b/src/main/java/com/couponmoa/backend/CouponmoaApplication.java
@@ -3,9 +3,7 @@ package com.couponmoa.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
-import org.springframework.scheduling.annotation.EnableAsync;
 
-@EnableAsync
 @SpringBootApplication
 @EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 public class CouponmoaApplication {

--- a/src/main/java/com/couponmoa/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/couponmoa/backend/common/exception/ErrorCode.java
@@ -33,7 +33,6 @@ public enum ErrorCode {
 
     // user coupon
     USER_COUPON_NOT_FOUND(NOT_FOUND, "사용자 쿠폰을 찾을 수 없습니다."),
-    USER_COUPON_ALREADY_ISSUED(CONFLICT, "이미 발급받은 쿠폰입니다."),
     USER_COUPON_ACCESS_DENIED(FORBIDDEN, "해당 쿠폰에 대한 권한이 없습니다."),
     USER_COUPON_CODE_UNAVAILABLE(BAD_REQUEST, "쿠폰이 이미 사용되었거나 만료되었습니다."),
 

--- a/src/main/java/com/couponmoa/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/couponmoa/backend/common/exception/ErrorCode.java
@@ -8,11 +8,12 @@ import static org.springframework.http.HttpStatus.*;
 @Getter
 public enum ErrorCode {
 
-    // subscribe
-    DUPLICATED_USER_COUPON(CONFLICT, "이미 구독한 쿠폰입니다."),
-
     // common
     FORBIDDEN_ADMIN_ONLY(FORBIDDEN, "ADMIN 권한을 가진 유저만 접근할 수 있습니다."),
+    EXCEPTION(INTERNAL_SERVER_ERROR, "알 수 없는 에러입니다."),
+
+    // subscribe
+    DUPLICATED_USER_COUPON(CONFLICT, "이미 구독한 쿠폰입니다."),
 
     // auth
     TOKEN_NOT_FOUND(NOT_FOUND, "존재하지 않는 토큰입니다."),
@@ -36,9 +37,6 @@ public enum ErrorCode {
     USER_COUPON_ACCESS_DENIED(FORBIDDEN, "해당 쿠폰에 대한 권한이 없습니다."),
     USER_COUPON_CODE_UNAVAILABLE(BAD_REQUEST, "쿠폰이 이미 사용되었거나 만료되었습니다."),
 
-    // server
-    EXCEPTION(INTERNAL_SERVER_ERROR, "알 수 없는 에러입니다."),
-
     // store
     STORE_NOT_FOUND(NOT_FOUND, "존재하지 않는 스토어 입니다."),
     NOT_VALIDATE_STORE_OWNER(UNAUTHORIZED,"남의 스토어를 건들지 마라" ),
@@ -51,9 +49,8 @@ public enum ErrorCode {
     INVALID_EXPIRY_DATE(BAD_REQUEST,"쿠폰 만료일은 발급 종료일 이후여야 합니다." ),
     COUPON_NOT_FOUND(NOT_FOUND,"존재하지 않는 쿠폰입니다." ),
     INVALID_TOTAL_QUANTITY(BAD_REQUEST,"새로운 총 수량은 이미 발급된 쿠폰 수보다 커야합니다." ),
-    COUPON_OUT_OF_STOCK(BAD_REQUEST,"쿠폰이 모두 소진되었습니다." ),
     COUPON_NOT_ACTIVE(BAD_REQUEST, "쿠폰 발급 기간이 아닙니다."),
-    COUPON_SOLE_OUT(BAD_REQUEST, "쿠폰이 모두 소진되었습니다."),
+    COUPON_SOLD_OUT(BAD_REQUEST, "쿠폰이 모두 소진되었습니다."),
     INVALID_END_DATE(BAD_REQUEST,"쿠폰 발급 시작일은 종료일보다 이전이어야 합니다." );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/couponmoa/backend/config/AsyncConfig.java
+++ b/src/main/java/com/couponmoa/backend/config/AsyncConfig.java
@@ -1,0 +1,18 @@
+package com.couponmoa.backend.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Slf4j
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params)
+                -> log.error("[Async Exception] Method: {}, Params: {}, Exception: {}", method.getName(), params, ex.getMessage(), ex);
+    }
+}

--- a/src/main/java/com/couponmoa/backend/config/RedisConfig.java
+++ b/src/main/java/com/couponmoa/backend/config/RedisConfig.java
@@ -4,9 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -31,5 +34,13 @@ public class RedisConfig {
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
         return template;
+    }
+
+    @Bean
+    public RedisScript<Long> couponIssueScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("scripts/coupon_issue.lua"));
+        script.setResultType(Long.class);
+        return script;
     }
 }

--- a/src/main/java/com/couponmoa/backend/domain/coupon/dto/response/CouponDetailResponseDto.java
+++ b/src/main/java/com/couponmoa/backend/domain/coupon/dto/response/CouponDetailResponseDto.java
@@ -51,7 +51,7 @@ public class CouponDetailResponseDto {
                 .expiryDate(coupon.getExpiryDate())
                 .createdAt(coupon.getCreatedAt())
                 .modifiedAt(coupon.getModifiedAt())
-                .status(CouponStatus.editStatus(coupon.getStartDate(), coupon.getEndDate()))
+                .status(coupon.getStatus())
                 .build();
     }
 }

--- a/src/main/java/com/couponmoa/backend/domain/coupon/dto/response/CouponDetailResponseDto.java
+++ b/src/main/java/com/couponmoa/backend/domain/coupon/dto/response/CouponDetailResponseDto.java
@@ -51,7 +51,7 @@ public class CouponDetailResponseDto {
                 .expiryDate(coupon.getExpiryDate())
                 .createdAt(coupon.getCreatedAt())
                 .modifiedAt(coupon.getModifiedAt())
-                .status(CouponStatus.editStatus(coupon.getStartDate(), coupon.getEndDate(), coupon.getAvailableQuantity()))
+                .status(CouponStatus.editStatus(coupon.getStartDate(), coupon.getEndDate()))
                 .build();
     }
 }

--- a/src/main/java/com/couponmoa/backend/domain/coupon/dto/response/CouponSimpleResponseDto.java
+++ b/src/main/java/com/couponmoa/backend/domain/coupon/dto/response/CouponSimpleResponseDto.java
@@ -34,7 +34,7 @@ public class CouponSimpleResponseDto {
                 .discountRate(coupon.getDiscountRate())
                 .startDate(coupon.getStartDate())
                 .endDate(coupon.getEndDate())
-                .status(CouponStatus.editStatus(coupon.getStartDate(), coupon.getEndDate(), coupon.getAvailableQuantity()))
+                .status(CouponStatus.editStatus(coupon.getStartDate(), coupon.getEndDate()))
                 .build();
     }
 }

--- a/src/main/java/com/couponmoa/backend/domain/coupon/dto/response/CouponSimpleResponseDto.java
+++ b/src/main/java/com/couponmoa/backend/domain/coupon/dto/response/CouponSimpleResponseDto.java
@@ -34,7 +34,7 @@ public class CouponSimpleResponseDto {
                 .discountRate(coupon.getDiscountRate())
                 .startDate(coupon.getStartDate())
                 .endDate(coupon.getEndDate())
-                .status(CouponStatus.editStatus(coupon.getStartDate(), coupon.getEndDate()))
+                .status(coupon.getStatus())
                 .build();
     }
 }

--- a/src/main/java/com/couponmoa/backend/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/couponmoa/backend/domain/coupon/entity/Coupon.java
@@ -95,13 +95,6 @@ public class Coupon extends BaseEntity {
         this.deletedAt = LocalDateTime.now();
     }
 
-    public void issuedQuantityUp() {
-        if (issuedQuantity >= totalQuantity) {
-            throw new IllegalStateException("쿠폰 발급 수량은 전체 수량을 초과할 수 없습니다.");
-        }
-        issuedQuantity++;
-    }
-
     public int getAvailableQuantity() {
         return totalQuantity - issuedQuantity;
     }

--- a/src/main/java/com/couponmoa/backend/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/couponmoa/backend/domain/coupon/entity/Coupon.java
@@ -23,8 +23,7 @@ public class Coupon extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
-    private int totalQuantity;  // 반드시 availableQuantity와 함께 수정되어야 함.
-    private int availableQuantity; // 서버에서 자동으로 설정.
+    private int totalQuantity;
     private int issuedQuantity;
     private BigDecimal discountAmount;
     private BigDecimal discountRate;
@@ -52,7 +51,6 @@ public class Coupon extends BaseEntity {
 
         this.name = name;
         this.totalQuantity = totalQuantity;
-        this.availableQuantity = totalQuantity;
         this.issuedQuantity = 0;
         this.discountAmount = discountAmount;
         this.discountRate = discountRate;
@@ -67,18 +65,11 @@ public class Coupon extends BaseEntity {
     }
 
     public void updateQuantity(int newTotalQuantity) {
-        int issuedCouponQuantity = this.totalQuantity - this.availableQuantity;
-
-        //이 부분 트래픽증가시 동시성이슈로 인해 예외 발생 가능성 매우 높음.
-        if (newTotalQuantity < issuedCouponQuantity) {
+        if (newTotalQuantity < this.issuedQuantity) {
             throw new ApplicationException(ErrorCode.INVALID_TOTAL_QUANTITY);
         }
 
-        int newAvailableQuantity = Math.max(0, newTotalQuantity - issuedCouponQuantity);
-
         this.totalQuantity = newTotalQuantity;
-        this.availableQuantity = newAvailableQuantity;
-        this.issuedQuantity = issuedCouponQuantity;
     }
 
     public void update(String name, BigDecimal discountAmount, BigDecimal discountRate,
@@ -104,15 +95,14 @@ public class Coupon extends BaseEntity {
         this.deletedAt = LocalDateTime.now();
     }
 
-    public void availableQuantityDown() {
-        if (availableQuantity <= 0) {
-            throw new IllegalStateException("쿠폰 잔여 개수는 음수일 수 없습니다.");
+    public void issuedQuantityUp() {
+        if (issuedQuantity >= totalQuantity) {
+            throw new IllegalStateException("쿠폰 발급 수량은 전체 수량을 초과할 수 없습니다.");
         }
-        availableQuantity--;
         issuedQuantity++;
+    }
 
-        if (availableQuantity == 0) {
-            this.status = CouponStatus.SOLD_OUT;
-        }
+    public int getAvailableQuantity() {
+        return totalQuantity - issuedQuantity;
     }
 }

--- a/src/main/java/com/couponmoa/backend/domain/coupon/enums/CouponStatus.java
+++ b/src/main/java/com/couponmoa/backend/domain/coupon/enums/CouponStatus.java
@@ -8,13 +8,9 @@ import java.time.LocalDateTime;
 @Getter
 @RequiredArgsConstructor
 public enum CouponStatus {
-    UPCOMING, IN_PROGRESS, SOLD_OUT, ENDED;
+    UPCOMING, IN_PROGRESS, ENDED;
 
-    public static CouponStatus editStatus(LocalDateTime startDate, LocalDateTime endDate, int availableQuantity) {
-        if (availableQuantity == 0) {
-            return CouponStatus.SOLD_OUT;
-        }
-
+    public static CouponStatus editStatus(LocalDateTime startDate, LocalDateTime endDate) {
         LocalDateTime now = LocalDateTime.now();
 
         if (now.isBefore(startDate)) {
@@ -31,4 +27,3 @@ public enum CouponStatus {
 // UPCOMING 상태만 유효함.
 // 이후에는 시간의 흐름에 따라 자동으로 변경 or 업데이트 시 자동으로 변경( 카테고리를 직접 변경할 수는 없음)
 // + 조회해서 응답값으로 반환할때도 변경이 되도록 로직 추가. 뭔가 더해야할까 ?
-// Coupon이 다 소진되었을때도 ENDED로 변경됩니다.

--- a/src/main/java/com/couponmoa/backend/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/couponmoa/backend/domain/coupon/service/CouponService.java
@@ -122,7 +122,7 @@ public class CouponService {
 
         // 쿠폰 상태 업데이트 (날짜, 발급수량에 따라)
         CouponStatus oldStatus = coupon.getStatus();
-        CouponStatus newStatus = editStatus(resolvedDates.startDate, resolvedDates.endDate, coupon.getAvailableQuantity());
+        CouponStatus newStatus = editStatus(resolvedDates.startDate, resolvedDates.endDate);
 
         // 상태가 실제로 변경되었을때만 updateStatus
         if (oldStatus != newStatus) {

--- a/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponAsyncService.java
+++ b/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponAsyncService.java
@@ -1,0 +1,28 @@
+package com.couponmoa.backend.domain.usercoupon.service;
+
+import com.couponmoa.backend.domain.coupon.entity.Coupon;
+import com.couponmoa.backend.domain.coupon.repository.CouponRepository;
+import com.couponmoa.backend.domain.user.entity.User;
+import com.couponmoa.backend.domain.user.repository.UserRepository;
+import com.couponmoa.backend.domain.usercoupon.entity.UserCoupon;
+import com.couponmoa.backend.domain.usercoupon.repository.UserCouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserCouponAsyncService {
+
+    private final UserRepository userRepository;
+    private final CouponRepository couponRepository;
+    private final UserCouponRepository userCouponRepository;
+
+    @Async
+    public void saveUserCoupon(Long userId, Long couponId) {
+        User user = userRepository.getReferenceById(userId);
+        Coupon coupon = couponRepository.getReferenceById(couponId);
+        UserCoupon userCoupon = new UserCoupon(user, coupon);
+        userCouponRepository.save(userCoupon);
+    }
+}

--- a/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponRedisService.java
+++ b/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponRedisService.java
@@ -1,0 +1,26 @@
+package com.couponmoa.backend.domain.usercoupon.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserCouponRedisService {
+
+    private static final String COUPON_KEY_PREFIX = "coupon:";
+    private static final String COUPON_STOCK_SUFFIX = ":stock";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisScript<Long> couponIssueScript;
+
+    public Integer couponIssue(Long userId, Long couponId) {
+        String stockKey = COUPON_KEY_PREFIX + couponId + COUPON_STOCK_SUFFIX;
+        String userSetKey = COUPON_KEY_PREFIX + couponId;
+        Long resultCode = redisTemplate.execute(couponIssueScript, List.of(stockKey, userSetKey), String.valueOf(userId));
+        return Math.toIntExact(resultCode);
+    }
+}

--- a/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponService.java
+++ b/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponService.java
@@ -24,35 +24,35 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserCouponService {
 
     private final UserRepository userRepository;
     private final CouponRepository couponRepository;
     private final UserCouponRepository userCouponRepository;
+    private final UserCouponRedisService userCouponRedisService;
 
-    @Transactional
     public void createUserCoupon(Long userId, Long couponId) {
         Coupon coupon = couponRepository.findActiveByIdOrElseThrow(couponId, ErrorCode.COUPON_NOT_FOUND);
-
         validateCouponIssuable(coupon.getStatus());
-        validateCouponNotAlreadyIssued(userId, couponId);
 
-        coupon.issuedQuantityUp();
-        couponRepository.flush();
+        Integer resultCode = userCouponRedisService.couponIssue(userId, couponId);
+        validateIssueResultCode(resultCode);
 
+        // TODO: 쿠폰 발급 수량 및 발급한 사용자 정보 업데이트 비동기 처리
         User user = userRepository.getReferenceById(userId);
         UserCoupon userCoupon = new UserCoupon(user, coupon);
         userCouponRepository.save(userCoupon);
     }
 
+    @Transactional(readOnly = true)
     public Page<UserCouponResponse> findUserCoupons(Long userId, UserCouponStatus status, Integer page, Integer size) {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
         return userCouponRepository.findByUserIdAndStatus(userId, status, pageable)
                 .map(UserCouponResponse::from);
     }
 
+    @Transactional(readOnly = true)
     public UserCouponCodeResponse findUserCouponCode(Long userId, Long userCouponId) {
         UserCoupon userCoupon = userCouponRepository.findByIdOrElseThrow(userCouponId, ErrorCode.USER_COUPON_NOT_FOUND);
 
@@ -80,14 +80,17 @@ public class UserCouponService {
         }
     }
 
-    private void validateCouponNotAlreadyIssued(Long userId, Long couponId) {
-        Boolean alreadyIssued = userCouponRepository.existsByUserIdAndCouponId(userId, couponId);
-        if (alreadyIssued) {
-            throw new ApplicationException(ErrorCode.USER_COUPON_ALREADY_ISSUED);
+    private void validateIssueResultCode(Integer resultCode) {
+        switch (resultCode) {
+            case 0: return;
+            case 1: throw new IllegalStateException("쿠폰 재고가 redis에 등록되지 않았습니다.");
+            case 2: throw new ApplicationException(ErrorCode.DUPLICATED_USER_COUPON);
+            case 3: throw new ApplicationException(ErrorCode.COUPON_SOLD_OUT);
+            default: throw new IllegalStateException("예상하지 못한 값이 반환되었습니다.");
         }
     }
 
-    private static void validateCouponOwner(User userCouponOwner, Long userId) {
+    private void validateCouponOwner(User userCouponOwner, Long userId) {
         if (!userCouponOwner.getId().equals(userId)) {
             throw new ApplicationException(ErrorCode.USER_COUPON_ACCESS_DENIED);
         }
@@ -99,7 +102,7 @@ public class UserCouponService {
         }
     }
 
-    private static void validateCouponStoreOwner(Store store, Long userId) {
+    private void validateCouponStoreOwner(Store store, Long userId) {
         if (!store.getUser().getId().equals(userId)) {
             throw new ApplicationException(ErrorCode.USER_COUPON_ACCESS_DENIED);
         }

--- a/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponService.java
+++ b/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponService.java
@@ -39,7 +39,7 @@ public class UserCouponService {
         validateCouponIssuable(coupon.getStatus());
         validateCouponNotAlreadyIssued(userId, couponId);
 
-        coupon.availableQuantityDown();
+        coupon.issuedQuantityUp();
         couponRepository.flush();
 
         User user = userRepository.getReferenceById(userId);
@@ -75,10 +75,6 @@ public class UserCouponService {
     }
 
     private void validateCouponIssuable(CouponStatus status) {
-        if (status == CouponStatus.SOLD_OUT) {
-            throw new ApplicationException(ErrorCode.COUPON_SOLD_OUT);
-        }
-
         if (status != CouponStatus.IN_PROGRESS) {
             throw new ApplicationException(ErrorCode.COUPON_NOT_ACTIVE);
         }

--- a/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponService.java
+++ b/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponService.java
@@ -7,7 +7,6 @@ import com.couponmoa.backend.domain.coupon.enums.CouponStatus;
 import com.couponmoa.backend.domain.coupon.repository.CouponRepository;
 import com.couponmoa.backend.domain.store.entity.Store;
 import com.couponmoa.backend.domain.user.entity.User;
-import com.couponmoa.backend.domain.user.repository.UserRepository;
 import com.couponmoa.backend.domain.usercoupon.dto.request.UserCouponRequest;
 import com.couponmoa.backend.domain.usercoupon.dto.response.UseUserCouponResponse;
 import com.couponmoa.backend.domain.usercoupon.dto.response.UserCouponCodeResponse;
@@ -27,10 +26,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserCouponService {
 
-    private final UserRepository userRepository;
     private final CouponRepository couponRepository;
     private final UserCouponRepository userCouponRepository;
     private final UserCouponRedisService userCouponRedisService;
+    private final UserCouponAsyncService userCouponAsyncService;
 
     public void createUserCoupon(Long userId, Long couponId) {
         Coupon coupon = couponRepository.findActiveByIdOrElseThrow(couponId, ErrorCode.COUPON_NOT_FOUND);
@@ -39,10 +38,7 @@ public class UserCouponService {
         Integer resultCode = userCouponRedisService.couponIssue(userId, couponId);
         validateIssueResultCode(resultCode);
 
-        // TODO: 쿠폰 발급 수량 및 발급한 사용자 정보 업데이트 비동기 처리
-        User user = userRepository.getReferenceById(userId);
-        UserCoupon userCoupon = new UserCoupon(user, coupon);
-        userCouponRepository.save(userCoupon);
+        userCouponAsyncService.saveUserCoupon(userId, couponId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponService.java
+++ b/src/main/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponService.java
@@ -76,7 +76,7 @@ public class UserCouponService {
 
     private void validateCouponIssuable(CouponStatus status) {
         if (status == CouponStatus.SOLD_OUT) {
-            throw new ApplicationException(ErrorCode.COUPON_SOLE_OUT);
+            throw new ApplicationException(ErrorCode.COUPON_SOLD_OUT);
         }
 
         if (status != CouponStatus.IN_PROGRESS) {

--- a/src/main/resources/scripts/coupon_issue.lua
+++ b/src/main/resources/scripts/coupon_issue.lua
@@ -1,0 +1,23 @@
+-- KEYS[1]: stock key (ex. coupon:1:stock)
+-- KEYS[2]: user set key (ex. coupon:1)
+-- ARGV[1]: userId
+
+-- 중복 발급 검사
+if redis.call("SISMEMBER", KEYS[2], ARGV[1]) == 1 then
+    return 2
+end
+
+-- 재고 검사
+local stock = tonumber(redis.call("GET", KEYS[1]))
+if not stock then
+    return 1 -- 재고 등록 안 됨
+end
+
+if stock <= 0 then
+    return 3 -- 재고 소진
+end
+
+-- 쿠폰 발급 성공
+redis.call("DECR", KEYS[1])
+redis.call("SADD", KEYS[2], ARGV[1])
+return 0

--- a/src/test/java/com/couponmoa/backend/domain/coupon/controller/CouponControllerTest.java
+++ b/src/test/java/com/couponmoa/backend/domain/coupon/controller/CouponControllerTest.java
@@ -9,6 +9,7 @@ import com.couponmoa.backend.domain.coupon.dto.response.CouponDetailResponseDto;
 import com.couponmoa.backend.domain.coupon.dto.response.CouponResponseDto;
 import com.couponmoa.backend.domain.coupon.dto.response.CouponSimpleResponseDto;
 import com.couponmoa.backend.domain.coupon.entity.Coupon;
+import com.couponmoa.backend.domain.coupon.enums.CouponStatus;
 import com.couponmoa.backend.domain.coupon.service.CouponReadService;
 import com.couponmoa.backend.domain.coupon.service.CouponService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -140,6 +141,7 @@ class CouponControllerTest {
                 .minOrderAmount(new BigDecimal("5000"))
                 .maxDiscountAmount(null)
                 .description("테스트를_위한_쿠폰")
+                .status(CouponStatus.IN_PROGRESS)
                 .startDate(LocalDateTime.now().minusDays(1))
                 .endDate(LocalDateTime.now().plusDays(1))
                 .expiryDate(LocalDateTime.now().plusDays(5))

--- a/src/test/java/com/couponmoa/backend/domain/usercoupon/controller/UserCouponControllerTest.java
+++ b/src/test/java/com/couponmoa/backend/domain/usercoupon/controller/UserCouponControllerTest.java
@@ -83,7 +83,7 @@ class UserCouponControllerTest {
             AuthUser authUser = new AuthUser(1L, "temp@gmail.com", UserRole.ROLE_USER);
             JwtAuthenticationToken authentication = new JwtAuthenticationToken(authUser);
 
-            ErrorCode errorCode = ErrorCode.COUPON_SOLE_OUT;
+            ErrorCode errorCode = ErrorCode.COUPON_SOLD_OUT;
             doThrow(new ApplicationException(errorCode))
                     .when(userCouponService).createUserCoupon(anyLong(), anyLong());
 

--- a/src/test/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponAsyncServiceTest.java
+++ b/src/test/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponAsyncServiceTest.java
@@ -1,0 +1,53 @@
+package com.couponmoa.backend.domain.usercoupon.service;
+
+import com.couponmoa.backend.domain.coupon.entity.Coupon;
+import com.couponmoa.backend.domain.coupon.repository.CouponRepository;
+import com.couponmoa.backend.domain.user.entity.User;
+import com.couponmoa.backend.domain.user.repository.UserRepository;
+import com.couponmoa.backend.domain.usercoupon.entity.UserCoupon;
+import com.couponmoa.backend.domain.usercoupon.repository.UserCouponRepository;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+@ExtendWith(MockitoExtension.class)
+class UserCouponAsyncServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private CouponRepository couponRepository;
+    @Mock
+    private UserCouponRepository userCouponRepository;
+    @InjectMocks
+    private UserCouponAsyncService userCouponAsyncService;
+
+    @Nested
+    @Order(1)
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class SaveUserCouponTests {
+
+        private static final long userId = 1L;
+        private static final long couponId = 1L;
+
+        @Test
+        @Order(1)
+        void 사용자_쿠폰_저장_성공() {
+            given(userRepository.getReferenceById(anyLong())).willReturn(mock(User.class));
+            given(couponRepository.getReferenceById(anyLong())).willReturn(mock(Coupon.class));
+
+            userCouponAsyncService.saveUserCoupon(userId, couponId);
+
+            verify(userCouponRepository).save(any(UserCoupon.class));
+        }
+    }
+}

--- a/src/test/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponRedisServiceTest.java
+++ b/src/test/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponRedisServiceTest.java
@@ -1,0 +1,42 @@
+package com.couponmoa.backend.domain.usercoupon.service;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+@ExtendWith(MockitoExtension.class)
+class UserCouponRedisServiceTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+    @InjectMocks
+    private UserCouponRedisService userCouponRedisService;
+
+    @Nested
+    @Order(1)
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class CouponIssueTests {
+
+        private static final long userId = 1L;
+        private static final long couponId = 1L;
+
+        @Test
+        @Order(1)
+        void 쿠폰_발급_스크립트_호출_성공() {
+            long resultCode = 0;
+            given(redisTemplate.execute(any(), anyList(), anyString())).willReturn(resultCode);
+
+            Integer result = userCouponRedisService.couponIssue(userId, couponId);
+
+            assertEquals(Math.toIntExact(resultCode), result);
+        }
+    }
+}

--- a/src/test/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponServiceTest.java
+++ b/src/test/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponServiceTest.java
@@ -7,7 +7,6 @@ import com.couponmoa.backend.domain.coupon.enums.CouponStatus;
 import com.couponmoa.backend.domain.coupon.repository.CouponRepository;
 import com.couponmoa.backend.domain.store.entity.Store;
 import com.couponmoa.backend.domain.user.entity.User;
-import com.couponmoa.backend.domain.user.repository.UserRepository;
 import com.couponmoa.backend.domain.usercoupon.dto.request.UserCouponRequest;
 import com.couponmoa.backend.domain.usercoupon.dto.response.UseUserCouponResponse;
 import com.couponmoa.backend.domain.usercoupon.dto.response.UserCouponCodeResponse;
@@ -37,11 +36,13 @@ import static org.mockito.Mockito.*;
 class UserCouponServiceTest {
 
     @Mock
-    private UserRepository userRepository;
-    @Mock
     private CouponRepository couponRepository;
     @Mock
     private UserCouponRepository userCouponRepository;
+    @Mock
+    private UserCouponRedisService userCouponRedisService;
+    @Mock
+    private UserCouponAsyncService userCouponAsyncService;
     @InjectMocks
     private UserCouponService userCouponService;
 
@@ -70,7 +71,7 @@ class UserCouponServiceTest {
 
         @Test
         @Order(2)
-        void 쿠폰_발급_기간_전_요청_실패() {
+        void 쿠폰_발급_IN_PROGRESS_상태_아님_실패() {
             ErrorCode errorCode = ErrorCode.COUPON_NOT_ACTIVE;
             Coupon coupon = mock();
             given(coupon.getStatus()).willReturn(CouponStatus.UPCOMING);
@@ -86,11 +87,12 @@ class UserCouponServiceTest {
 
         @Test
         @Order(3)
-        void 쿠폰_발급_기간_후_요청_실패() {
-            ErrorCode errorCode = ErrorCode.COUPON_NOT_ACTIVE;
+        void 쿠폰_발급_수량_없음_실패() {
+            ErrorCode errorCode = ErrorCode.COUPON_SOLD_OUT;
             Coupon coupon = mock();
-            given(coupon.getStatus()).willReturn(CouponStatus.ENDED);
+            given(coupon.getStatus()).willReturn(CouponStatus.IN_PROGRESS);
             given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);
+            given(userCouponRedisService.couponIssue(anyLong(), anyLong())).willReturn(3);
 
             ApplicationException thrown = assertThrows(ApplicationException.class,
                     () -> userCouponService.createUserCoupon(userId, couponId));
@@ -102,10 +104,12 @@ class UserCouponServiceTest {
 
         @Test
         @Order(4)
-        void 쿠폰_발급_수량_없음_실패() {
-            ErrorCode errorCode = ErrorCode.COUPON_SOLD_OUT;
+        void 쿠폰_발급_중복_요청_실패() {
+            ErrorCode errorCode = ErrorCode.DUPLICATED_USER_COUPON;
             Coupon coupon = mock();
+            given(coupon.getStatus()).willReturn(CouponStatus.IN_PROGRESS);
             given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);
+            given(userCouponRedisService.couponIssue(anyLong(), anyLong())).willReturn(2);
 
             ApplicationException thrown = assertThrows(ApplicationException.class,
                     () -> userCouponService.createUserCoupon(userId, couponId));
@@ -117,36 +121,43 @@ class UserCouponServiceTest {
 
         @Test
         @Order(5)
-        void 쿠폰_발급_중복_요청_실패() {
-            ErrorCode errorCode = ErrorCode.USER_COUPON_ALREADY_ISSUED;
+        void 쿠폰_발급_redis에_쿠폰_재고_등록_안됨_실패() {
             Coupon coupon = mock();
             given(coupon.getStatus()).willReturn(CouponStatus.IN_PROGRESS);
             given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);
-            given(userCouponRepository.existsByUserIdAndCouponId(anyLong(), anyLong())).willReturn(true);
+            given(userCouponRedisService.couponIssue(anyLong(), anyLong())).willReturn(1);
 
-            ApplicationException thrown = assertThrows(ApplicationException.class,
+            IllegalStateException thrown = assertThrows(IllegalStateException.class,
                     () -> userCouponService.createUserCoupon(userId, couponId));
 
             assertNotNull(thrown);
-            assertEquals(errorCode.getMessage(), thrown.getMessage());
-            assertEquals(errorCode.getHttpStatus(), thrown.getStatus());
         }
 
         @Test
         @Order(6)
-        void 쿠폰_발급_성공() {
-            User user = mock();
+        void 쿠폰_발급_lua_script_예상_못한_값_반환_실패() {
             Coupon coupon = mock();
             given(coupon.getStatus()).willReturn(CouponStatus.IN_PROGRESS);
             given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);
-            given(userCouponRepository.existsByUserIdAndCouponId(anyLong(), anyLong())).willReturn(false);
-            given(userRepository.getReferenceById(anyLong())).willReturn(user);
+            given(userCouponRedisService.couponIssue(anyLong(), anyLong())).willReturn(-1);
+
+            IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                    () -> userCouponService.createUserCoupon(userId, couponId));
+
+            assertNotNull(thrown);
+        }
+
+        @Test
+        @Order(7)
+        void 쿠폰_발급_성공() {
+            Coupon coupon = mock();
+            given(coupon.getStatus()).willReturn(CouponStatus.IN_PROGRESS);
+            given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);
+            given(userCouponRedisService.couponIssue(anyLong(), anyLong())).willReturn(0);
 
             userCouponService.createUserCoupon(userId, couponId);
 
-            verify(coupon, times(1)).issuedQuantityUp();
-            verify(couponRepository, times(1)).flush();
-            verify(userCouponRepository, times(1)).save(any(UserCoupon.class));
+            verify(userCouponAsyncService, times(1)).saveUserCoupon(anyLong(), anyLong());
         }
     }
 

--- a/src/test/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponServiceTest.java
+++ b/src/test/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponServiceTest.java
@@ -105,7 +105,6 @@ class UserCouponServiceTest {
         void 쿠폰_발급_수량_없음_실패() {
             ErrorCode errorCode = ErrorCode.COUPON_SOLD_OUT;
             Coupon coupon = mock();
-            given(coupon.getStatus()).willReturn(CouponStatus.SOLD_OUT);
             given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);
 
             ApplicationException thrown = assertThrows(ApplicationException.class,
@@ -145,7 +144,7 @@ class UserCouponServiceTest {
 
             userCouponService.createUserCoupon(userId, couponId);
 
-            verify(coupon, times(1)).availableQuantityDown();
+            verify(coupon, times(1)).issuedQuantityUp();
             verify(couponRepository, times(1)).flush();
             verify(userCouponRepository, times(1)).save(any(UserCoupon.class));
         }

--- a/src/test/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponServiceTest.java
+++ b/src/test/java/com/couponmoa/backend/domain/usercoupon/service/UserCouponServiceTest.java
@@ -22,7 +22,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.*;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.Optional;
@@ -104,7 +103,7 @@ class UserCouponServiceTest {
         @Test
         @Order(4)
         void 쿠폰_발급_수량_없음_실패() {
-            ErrorCode errorCode = ErrorCode.COUPON_SOLE_OUT;
+            ErrorCode errorCode = ErrorCode.COUPON_SOLD_OUT;
             Coupon coupon = mock();
             given(coupon.getStatus()).willReturn(CouponStatus.SOLD_OUT);
             given(couponRepository.findActiveByIdOrElseThrow(anyLong(), any(ErrorCode.class))).willReturn(coupon);


### PR DESCRIPTION
## 📌 반영 브랜치
feat/coupon-issue -> dev

## 🚨 연관 이슈
Resolve: #69 

## ✅ 작업 내용 `기능 개선`
- Coupon 엔티티 상태 중 SOLD_OUT 제거 & availableQuantity 필드 제거 -> redis에서 제어
- Redis와 lua script를 적용해 쿠폰 발급 시 동시성 제어 구현
- 쿠폰 발급 성공 시 UserCoupon 저장 비동기로 처리
- 기존 테스트 코드 수정 및 신규 메서드 테스트 코드 추가

## 🎯 단독 테스트 결과
테스트 성공